### PR TITLE
Upgrade flask v2

### DIFF
--- a/{{cookiecutter.project_folder}}/Pipfile
+++ b/{{cookiecutter.project_folder}}/Pipfile
@@ -6,11 +6,11 @@ name = "pypi"
 [packages]
 Flask-SQLAlchemy = "==2.4.4"
 SQLAlchemy = "==1.4.3"
-Flask-Script = "==2.0.6"
-py-ms = {extras = ["all"],version = "==2.7.0"}
+pyms = {extras = ["all"],git = "https://github.com/humboldtramirez/pyms.git", editable = true, ref = "master"} # fork supporting Flask 2.0
 marshmallow = "==3.8.0"
 marshmallow-sqlalchemy = ">=0.24.2"
-importlib-metadata = "==2.1.1"
+importlib-metadata = ">2.1.1" # resolve TypeError: entry_points() got an unexpected keyword argument 'group'
+werkzeug = "==2.0.0" # downgrade to resolve "KeyError: 'WERKZEUG_SERVER_FD'"
 
 [dev-packages]
 requests-mock = "*"

--- a/{{cookiecutter.project_folder}}/README.md
+++ b/{{cookiecutter.project_folder}}/README.md
@@ -42,7 +42,9 @@ For a more in-depth explanation please refer to  the [official documentation](ht
 
 ## Run your python script
 ```bash
-python manage.py runserver
+export FLASK_APP=manage.py
+export FLASK_ENV=development
+python manage.py run
 ```
 
 
@@ -87,7 +89,7 @@ https://microservices-scaffold.readthedocs.io/en/latest/
 You can dockerize this microservice with these steps:
 * Create and push the image
 
-    docker build -t films -f Dockerfile .
+    docker build -t [image_name[:optional_tag]] -f Dockerfile .
 * Run the image:
 
-    docker run -d -p 5000:5000 films
+    docker run -d -p 5000:5000 [image_name]

--- a/{{cookiecutter.project_folder}}/manage.py
+++ b/{{cookiecutter.project_folder}}/manage.py
@@ -1,11 +1,11 @@
 # encoding: utf-8
-from flask_script import Manager
+from flask.cli import FlaskGroup
 
 from project.app import create_app
 
 app = create_app()
 
-manager = Manager(app)
+cli = FlaskGroup(app)
 
 if __name__ == '__main__':
-    manager.run()
+    cli()

--- a/{{cookiecutter.project_folder}}/pylintrc
+++ b/{{cookiecutter.project_folder}}/pylintrc
@@ -257,13 +257,6 @@ max-line-length=120
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no

--- a/{{cookiecutter.project_folder}}/tests/test_views.py
+++ b/{{cookiecutter.project_folder}}/tests/test_views.py
@@ -3,7 +3,6 @@ import os
 import unittest
 from project.app import MyMicroservice
 from pyms.constants import CONFIGMAP_FILE_ENVIRONMENT
-from typing import Dict, List, Union, Text
 
 
 class ProjectTestCase(unittest.TestCase):
@@ -19,12 +18,14 @@ class ProjectTestCase(unittest.TestCase):
     def tearDown(self):
         pass  # os.unlink(self.app.config['DATABASE'])
 
+
     {%- if cookiecutter.application_root != '/' %}
     def test_home(self):
         response = self.client.get('/')
         self.assertEqual(404, response.status_code)
     {% endif -%}
     
+
     def test_healthcheck(self):
         response = self.client.get('/healthcheck')
         self.assertEqual(200, response.status_code)

--- a/{{cookiecutter.project_folder}}/tox.ini
+++ b/{{cookiecutter.project_folder}}/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 envlist = py36,pylint,flake8,safety,bandit
 
+[flake8]
+ignore = E501
+max-line-length = 120
+
 [testenv]
 setenv =
     PYMS_CONFIGMAP_FILE=tests/config-tests.yml


### PR DESCRIPTION
PyMS has merged a commit that upgrades support to Flask 2.0 but hasn't created a new release. This change will use a fork of PyMS with Flask 2.0 support